### PR TITLE
fix(docs): correct Streamlit y, fix typo, await gen_data_run, declare dataset

### DIFF
--- a/user/docs/scenarios/etl/streamlit.md
+++ b/user/docs/scenarios/etl/streamlit.md
@@ -25,7 +25,7 @@ rdf = pd.read_json("result.json", orient="records")
 rdf.columns = rdf.columns.str.replace(":", "")
 
 st.write("""My data""")
-st.line_chart(rdf, x="codice spira", y="1200-1300")
+st.line_chart(rdf, x="codice spira", y="value")
 ```
 
 ## Launch app

--- a/user/docs/scenarios/mlsklearn/intro.md
+++ b/user/docs/scenarios/mlsklearn/intro.md
@@ -58,7 +58,7 @@ data_gen_fn = project.new_function(name="data-prep",
 Run it:
 
 ```python
-gen_data_run = data_gen_fn.run("job")
+gen_data_run = data_gen_fn.run("job",wait=True)
 ```
 
 You can view the state of the execution with `gen_data_run.status` or its output with `gen_data_run.outputs()`. You can see a few records from the output artifact:

--- a/user/docs/scenarios/mlsklearn/training.md
+++ b/user/docs/scenarios/mlsklearn/training.md
@@ -62,6 +62,7 @@ train_fn = project.new_function(
 and run it:
 
 ```python
+dataset = gen_data_run.output("dataset")
 train_run = train_fn.run(action="job", inputs={"di": dataset.key}, wait=True)
 ```
 

--- a/user/docs/tasks/secrets.md
+++ b/user/docs/tasks/secrets.md
@@ -1,6 +1,6 @@
 # Secret Management
 
-Working with different operations may implu the usage of a sensitive values, such as external API credentials,
+Working with different operations may imply the usage of a sensitive values, such as external API credentials,
 storage credentials, etc.
 
 In order to avoid embedding the credentials in the code of functions, the platform supports an explicit management


### PR DESCRIPTION
This PR groups a few small but important documentation/code-sample fixes:

1. Fix Streamlit example to use the correct `y` column: `value` instead of `1200-1300`.
2. Correct a typo in the "Secret management" doc: `implu` -> `imply`.
3. Ensure the data generation run is awaited: `gen_data_run = data_gen_fn.run("job", wait=True)`.
4. Declare the dataset before using it in training: call `dataset = gen_data_run.output("dataset")` prior to passing `dataset` to training/registering steps.